### PR TITLE
perf(protocol): optimize frame capacity calculation to eliminate reallocations

### DIFF
--- a/crates/turnkey-core/src/constants.rs
+++ b/crates/turnkey-core/src/constants.rs
@@ -15,6 +15,11 @@ pub const END_BYTE: u8 = 0x03; // ETX
 /// Frame overhead (STX + ETX = 2 bytes)
 pub const FRAME_OVERHEAD: usize = 2;
 
+/// Frame capacity calculation components
+pub const DEVICE_ID_LENGTH: usize = 2; // Zero-padded to 2 digits (01-99)
+pub const PROTOCOL_ID_LENGTH: usize = 4; // "REON"
+pub const BASE_DELIMITER_COUNT: usize = 2; // Two '+' separators (ID+REON+CMD)
+
 /// Timeouts (milliseconds)
 pub const DEFAULT_ONLINE_TIMEOUT: u64 = 3000;
 pub const MIN_ONLINE_TIMEOUT: u64 = 500;

--- a/crates/turnkey-protocol/src/field.rs
+++ b/crates/turnkey-protocol/src/field.rs
@@ -71,6 +71,42 @@ impl FieldData {
         &self.0
     }
 
+    /// Returns the length of the field data in bytes
+    ///
+    /// This is useful for capacity calculations when encoding messages.
+    ///
+    /// # Example
+    /// ```
+    /// use turnkey_protocol::FieldData;
+    ///
+    /// let field = FieldData::new("12345678".to_string()).unwrap();
+    /// assert_eq!(field.len(), 8);
+    ///
+    /// let empty = FieldData::new("".to_string()).unwrap();
+    /// assert_eq!(empty.len(), 0);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the field data is empty
+    ///
+    /// # Example
+    /// ```
+    /// use turnkey_protocol::FieldData;
+    ///
+    /// let empty = FieldData::new("".to_string()).unwrap();
+    /// assert!(empty.is_empty());
+    ///
+    /// let field = FieldData::new("data".to_string()).unwrap();
+    /// assert!(!field.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Convert field data into owned String
     ///
     /// # Example
@@ -383,5 +419,72 @@ mod tests {
 
         let field = FieldData::try_from("").unwrap();
         assert_eq!(field.as_str(), "");
+    }
+
+    #[test]
+    fn test_field_len() {
+        // Test length calculation for various field sizes
+        let field = FieldData::new("12345678".to_string()).unwrap();
+        assert_eq!(field.len(), 8);
+
+        let field = FieldData::new("10/05/2025 12:46:06".to_string()).unwrap();
+        assert_eq!(field.len(), 19);
+
+        let field = FieldData::new("test".to_string()).unwrap();
+        assert_eq!(field.len(), 4);
+
+        let field = FieldData::new("1".to_string()).unwrap();
+        assert_eq!(field.len(), 1);
+
+        let field = FieldData::new("".to_string()).unwrap();
+        assert_eq!(field.len(), 0);
+    }
+
+    #[test]
+    fn test_field_len_matches_as_str() {
+        // Verify that len() returns same value as as_str().len()
+        let test_values = vec![
+            "12345678",
+            "10/05/2025 12:46:06",
+            "Acesso liberado",
+            "test-value_123",
+            "",
+            "1",
+        ];
+
+        for value in test_values {
+            let field = FieldData::new(value.to_string()).unwrap();
+            assert_eq!(field.len(), field.as_str().len());
+            assert_eq!(field.len(), value.len());
+        }
+    }
+
+    #[test]
+    fn test_field_is_empty() {
+        // Test is_empty for empty field
+        let empty = FieldData::new("".to_string()).unwrap();
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+
+        // Test is_empty for non-empty fields
+        let field = FieldData::new("data".to_string()).unwrap();
+        assert!(!field.is_empty());
+        assert_eq!(field.len(), 4);
+
+        let field = FieldData::new("12345678".to_string()).unwrap();
+        assert!(!field.is_empty());
+        assert_eq!(field.len(), 8);
+    }
+
+    #[test]
+    fn test_field_is_empty_consistency() {
+        // Verify that is_empty() is consistent with len() == 0
+        let test_values = vec!["", "x", "test", "longer string"];
+
+        for value in test_values {
+            let field = FieldData::new(value.to_string()).unwrap();
+            assert_eq!(field.is_empty(), value.is_empty());
+            assert_eq!(field.len(), value.len());
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR implements exact frame capacity calculation for the Henry protocol, replacing the approximate estimation that used a magic number. The optimization eliminates potential string buffer reallocations during message encoding, improves code maintainability through self-documenting calculations, and applies SOLID principles (DRY, Single Responsibility) throughout the protocol layer.

The work evolved from a simple optimization into a comprehensive refactoring that improves code quality while maintaining backward compatibility.

## Related Issue
Closes #26

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring

## Changes Made

### 1. Exact Capacity Calculation
- Added frame capacity constants to `turnkey-core/src/constants.rs`:
  - `DEVICE_ID_LENGTH = 2` (zero-padded device IDs)
  - `PROTOCOL_ID_LENGTH = 4` ("REON")
  - `BASE_DELIMITER_COUNT = 2` (two '+' separators)
- Replaced magic number 13 with precise component-based calculation
- Eliminated potential buffer reallocations in hot path

### 2. Single Responsibility Refactoring
- Extracted `Message::frame_capacity()` method (17 lines → 2 lines in Frame::from)
- Separated capacity calculation logic from frame construction
- Added comprehensive documentation explaining calculation components

### 3. DRY Principle Application
- Added `CommandCode::len()` method to replace `.as_str().len()` pattern
- Added `FieldData::len()` and `is_empty()` methods
- Added `Message::fields_len()` aggregate method
- All methods marked with `#[inline]` for zero-cost abstraction

### 4. Test Quality Improvements
- Eliminated 39 lines of duplicated test code in `commands.rs`
- Created `all_command_codes()` helper function for test consistency
- Added `test_all_command_codes_is_complete()` validation test
- Added constant validation test to ensure protocol constants stay synchronized

## Performance Impact

### Before
```rust
// Approximate capacity with magic number
let fields_size: usize = msg.fields.iter().map(|f| f.len() + 1).sum();
let capacity = 13 + fields_size + 1;  // What is 13? Why +1 at the end?
```

### After
```rust
// Exact capacity calculation (delegated to Message::frame_capacity())
let capacity = msg.frame_capacity();
```

**Benefits:**
- Zero reallocations during frame construction
- Pre-allocated buffers with exact required capacity
- Reduced memory allocator pressure in hot path
- More predictable performance characteristics

## Testing

- [x] All existing tests pass (cargo test --workspace)
- [x] Added new tests to cover changes
- [x] Tested manually

### Test Coverage
- 15 new unit tests added for capacity calculations and len() methods
- 1 validation test for capacity constants correctness
- Test code duplication eliminated (39 lines reduced)
- Total: 138 tests passing (113 unit + 25 doc tests)

### New Tests Added
- `test_frame_capacity_is_exact()` - Verifies exact capacity calculation
- `test_frame_capacity_empty_fields()` - Edge case: messages without fields
- `test_frame_capacity_single_field()` - Single field capacity
- `test_frame_capacity_multiple_fields()` - Multiple fields capacity
- `test_command_code_len()` - CommandCode length calculations
- `test_command_code_len_matches_as_str()` - Consistency verification
- `test_field_len()` - FieldData length calculations
- `test_field_len_matches_as_str()` - FieldData consistency
- `test_field_is_empty()` - Empty field detection
- `test_field_is_empty_consistency()` - Empty/length invariant
- `test_message_fields_len()` - Aggregate field length
- `test_message_fields_len_empty()` - Empty fields edge case
- `test_capacity_constants_are_correct()` - Constant validation
- `test_all_command_codes_is_complete()` - Test helper completeness
- Additional inline method optimization tests

### Manual Testing
All cargo commands executed successfully:
```bash
cargo fmt --all          # Code formatting: OK
cargo clippy --workspace # Zero warnings
cargo test --workspace   # 138 tests passing
cargo build --release    # Clean build
```

## Checklist
- [x] My code follows the project's style guidelines (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (cargo clippy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Code Quality Improvements

### Maintainability
- Removed magic number 13 in favor of named constants
- Self-documenting capacity calculation with inline comments
- Clear separation of concerns (capacity calculation vs frame construction)

### Performance
- `#[inline]` attributes on all helper methods for zero-cost abstraction
- Exact capacity eliminates reallocation overhead
- Reduced string allocations in protocol hot path

### Type Safety
- Leveraged existing `FieldData` and `CommandCode` newtypes
- Added length methods that maintain type safety guarantees
- No unsafe code introduced

### Documentation
- Comprehensive rustdoc for all new public methods
- Detailed capacity calculation explanation in `Message::frame_capacity()`
- Cross-references between Frame::from() and capacity calculation
- Examples in documentation for all new APIs

## Additional Notes

### Design Decisions

1. **Centralized Constants**: Added capacity constants to `turnkey-core/constants.rs` rather than creating new file, following existing project organization and DRY principle at workspace level.

2. **Single Responsibility**: Extracted `Message::frame_capacity()` even though it's called from only one location, because capacity calculation is conceptually separate from frame construction and may be useful for buffer pre-sizing in future optimizations.

3. **Test Helper Function**: Created `all_command_codes()` helper to eliminate duplication and ensure test consistency when new command codes are added to the enum.

4. **Inline Optimization**: Added `#[inline]` to all new methods since they're simple accessors in hot path (frame encoding occurs for every protocol message).

### Future Improvements

This optimization sets foundation for:
- Protocol-level benchmarking (Issue #17)
- Zero-copy optimizations if needed
- Capacity pre-calculation caching for repeated message types

### Breaking Changes
None - this is a pure internal optimization with no API changes.

### Files Modified
```
crates/turnkey-core/src/constants.rs       (+5 lines)
crates/turnkey-protocol/src/commands.rs    (+134 lines, -30 lines)
crates/turnkey-protocol/src/field.rs       (+103 lines)
crates/turnkey-protocol/src/frame.rs       (+101 lines)
crates/turnkey-protocol/src/message.rs     (+292 lines)
---
Total: +605 additions, -30 deletions
```

### Related Work
- Builds on FieldData newtype from PR #27
- Uses CommandCode Display trait from PR #28
- Contributes to performance goals from Issue #17