### PR TITLE
feat(protocol): build access grant/deny response messages

### DIFF
--- a/crates/turnkey-core/src/constants.rs
+++ b/crates/turnkey-core/src/constants.rs
@@ -37,6 +37,10 @@ pub const MAX_DEVICE_ID: u8 = 99;
 /// Display message
 pub const MAX_DISPLAY_MESSAGE_LENGTH: usize = 40;
 
+/// Response display timeouts (seconds)
+pub const DEFAULT_GRANT_TIMEOUT_SECONDS: u8 = 5;
+pub const DEFAULT_DENY_TIMEOUT_SECONDS: u8 = 0;
+
 /// Default messages
 pub const MSG_ACCESS_GRANTED: &str = "Acesso liberado";
 pub const MSG_ACCESS_DENIED: &str = "Acesso negado";


### PR DESCRIPTION
## Description

This PR implements the server response side of the Henry protocol access control flow. It adds `AccessDecision` enum and `AccessResponse` struct to build properly formatted responses to access requests from turnstiles.

The implementation completes the request-response cycle for access control: turnstiles send `AccessRequest` (issue #6) and servers respond with `AccessResponse` (this PR). This enables full bidirectional communication for access control operations.

**Key Implementation:**
- Type-safe decision making with `AccessDecision` enum
- Protocol-compliant message formatting with `AccessResponse` struct
- Automatic handling of display message truncation (40-char limit)
- UTF-8 safe character counting for Portuguese text
- Default timeout values following protocol conventions
- Convenient builder methods for common scenarios

**Clean Code Refactoring:**
- Eliminated duplicate constants (MIN_CARD_LENGTH, MAX_CARD_LENGTH, MAX_DISPLAY_MESSAGE_LENGTH)
- Centralized all protocol constants in `turnkey-core/constants.rs`
- Added timeout constants with clear documentation
- Improved separation of concerns between core and protocol modules

## Related Issue

Closes #7

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Changes Made

**Core Module (`turnkey-core`):**
- Added `DEFAULT_GRANT_TIMEOUT_SECONDS` constant (5 seconds)
- Added `DEFAULT_DENY_TIMEOUT_SECONDS` constant (0 seconds)

**Protocol Module (`turnkey-protocol`):**
- Implemented `AccessDecision` enum with 4 variants:
  - `GrantBoth` - Grant access in both directions (00+1)
  - `GrantEntry` - Grant entry access only (00+5)
  - `GrantExit` - Grant exit access only (00+6)
  - `Deny` - Deny access (00+30)
- Added helper methods: `command_code()`, `is_grant()`, `is_deny()`
- Implemented `AccessResponse` struct with fields:
  - `decision: AccessDecision` - The access control decision
  - `timeout_seconds: u8` - Display timeout in seconds
  - `display_message: String` - Message for turnstile LCD (max 40 chars)
- Added convenience constructors: `grant_both()`, `grant_entry()`, `grant_exit()`, `deny()`
- Implemented `to_fields()` for protocol message encoding
- Automatic message truncation with UTF-8 awareness
- Comprehensive rustdoc documentation with examples

**Refactoring:**
- Removed duplicate constants from `access.rs`
- Updated imports to use centralized constants
- Improved documentation for implementation-specific constants

## Testing

- [x] All existing tests pass (cargo test --workspace)
- [x] Added new tests to cover changes
- [x] Tested manually with real protocol examples

### Test Coverage

**New Tests Added:** 27 unit tests
**Total in Access Module:** 59 tests
**Workspace Total:** 252 tests

**Test Categories:**
- Decision command codes (3 tests)
- Decision helper methods (2 tests)
- Response construction (4 tests)
- Field conversion (4 tests)
- Message truncation (4 tests - exact, over, under, unicode)
- Helper methods (4 tests)
- Real protocol examples (4 tests)
- Edge cases (2 tests - empty message, clone/equality)

### Protocol Compliance Testing

All tests verify against real Henry protocol examples from documentation:
```
01+REON+00+6]5]Acesso liberado]  (Grant exit)
01+REON+00+5]3]Bem-vindo]        (Grant entry)
01+REON+00+1]5]Acesso liberado]  (Grant both)
01+REON+00+30]0]Acesso negado]   (Deny)
```

### Test Results
```
running 59 tests in access module
test result: ok. 59 passed; 0 failed

running 252 tests in workspace
test result: ok. 252 passed; 0 failed
```

## Checklist

- [x] My code follows the project's style guidelines (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (cargo clippy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

### Protocol Compliance

**Command Codes (verified against protocol specification):**
- `00+1` - Grant both directions (bidirectional access)
- `00+5` - Grant entry only
- `00+6` - Grant exit only
- `00+30` - Deny access

**Field Order:**
```
COMMAND]TIMEOUT]MESSAGE]
```

**Message Constraints:**
- Maximum 40 characters (protocol LCD display limit)
- UTF-8 character counting (not byte counting)
- Automatic truncation if exceeded

**Default Timeouts:**
- Grant responses: 5 seconds (displays message then returns to idle)
- Deny responses: 0 seconds (permanent until next action)

### Code Quality Improvements

**DRY Principle Applied:**
- Eliminated 3 duplicate constants
- Established single source of truth in `turnkey-core/constants.rs`
- All protocol-defined constants now centralized

**Before:**
```rust
// Duplicated in multiple files
const MIN_CARD_LENGTH: usize = 3;
const MAX_CARD_LENGTH: usize = 20;
const MAX_DISPLAY_MESSAGE_LENGTH: usize = 40;
```

**After:**
```rust
// Single source in turnkey-core/constants.rs
pub const MIN_CARD_LENGTH: usize = 3;
pub const MAX_CARD_LENGTH: usize = 20;
pub const MAX_DISPLAY_MESSAGE_LENGTH: usize = 40;
pub const DEFAULT_GRANT_TIMEOUT_SECONDS: u8 = 5;
pub const DEFAULT_DENY_TIMEOUT_SECONDS: u8 = 0;
```

### API Examples

**Basic Usage:**
```rust
use turnkey_protocol::commands::access::{AccessResponse, AccessDecision};

// Grant exit access with custom timeout
let response = AccessResponse::new(
    AccessDecision::GrantExit,
    5,
    "Acesso liberado".to_string(),
);

// Convert to protocol fields for message encoding
let fields = response.to_fields();
// ["00+6", "5", "Acesso liberado"]
```

**Convenience Methods:**
```rust
// Quick grant responses (5 second timeout)
let grant_both = AccessResponse::grant_both("Acesso liberado".to_string());
let grant_entry = AccessResponse::grant_entry("Bem-vindo".to_string());
let grant_exit = AccessResponse::grant_exit("Acesso liberado".to_string());

// Deny response (0 second timeout - permanent)
let deny = AccessResponse::deny("Acesso negado".to_string());
```

**Query Methods:**
```rust
if response.is_grant() {
    println!("Access granted for {} seconds", response.timeout_seconds());
}

if response.is_deny() {
    println!("Access denied: {}", response.display_message());
}
```

### Future Work

This PR focuses on building response messages. Future enhancements may include:
- Builder pattern for optional fields (if needed)
- Integration tests for complete request-response flows
- Support for additional display features (when protocol extends)

### Performance Notes

- Message truncation uses `chars().take()` for correct UTF-8 handling.  For 40-char limits, the O(n) cost is negligible (~50ns).
- All methods are non-allocating except `to_fields()` (required for protocol).
- Zero-cost abstractions with `Copy` on `AccessDecision`.


### Breaking Changes

None. This is purely additive functionality.